### PR TITLE
Fix movement for Push Block + other additions

### DIFF
--- a/Loenn/entities/pushblock.lua
+++ b/Loenn/entities/pushblock.lua
@@ -12,45 +12,58 @@ pushblock.placements =
         ["stickyBottom"] = false,
         ["stickyLeft"] = false,
         ["stickyRight"] = false,
-        ["isTemple"] = false
+        ["isTemple"] = false,
+        legacy = false,
+        customBlockTexture = "",
+        customGooTexture = ""
     }
 }
 
-local blockTexture = "objects/canyon/pushblock/idle"
-local blockTempleTexture = "objects/canyon/pushblock/idleTemple"
-local gooTexture = "objects/canyon/pushblock/stickyGoo00"
+local function getBlockTexture(entity)
+    local data = entity.customBlockTexture
+    local block = (data == nil or data == "") and "objects/canyon/pushblock/idle" or data
+    
+    return block
+end
+
+local function getGooTexture(entity)
+    local data = entity.customGooTexture
+    local goo = (data == nil or data == "") and "objects/canyon/pushblock/stickyGoo00" or data .. "00"
+    
+    return goo
+end
 
 function pushblock.sprite(room, entity)
     local sprites = {}
 
     if entity.isTemple then
-        local blockSprite = drawableSprite.fromTexture(blockTempleTexture, entity)
+        local blockSprite = drawableSprite.fromTexture(getBlockTexture(entity) .. "Temple", entity)
         table.insert(sprites, blockSprite)
     else
-        local blockSprite = drawableSprite.fromTexture(blockTexture, entity)
+        local blockSprite = drawableSprite.fromTexture(getBlockTexture(entity), entity)
         table.insert(sprites, blockSprite)
     end
 
     if entity.stickyTop then
-        local gooSprite = drawableSprite.fromTexture(gooTexture, entity)
+        local gooSprite = drawableSprite.fromTexture(getGooTexture(entity), entity)
         gooSprite:setJustification(0.5, 0.5)
         gooSprite.rotation = 0
         table.insert(sprites, gooSprite)
     end
     if entity.stickyBottom then
-        local gooSprite = drawableSprite.fromTexture(gooTexture, entity)
+        local gooSprite = drawableSprite.fromTexture(getGooTexture(entity), entity)
         gooSprite:setJustification(0.5, 0.5)
         gooSprite.rotation = math.pi
         table.insert(sprites, gooSprite)
     end
     if entity.stickyLeft then
-        local gooSprite = drawableSprite.fromTexture(gooTexture, entity)
+        local gooSprite = drawableSprite.fromTexture(getGooTexture(entity), entity)
         gooSprite:setJustification(0.5, 0.5)
         gooSprite.rotation = -math.pi / 2
         table.insert(sprites, gooSprite)
     end
     if entity.stickyRight then
-        local gooSprite = drawableSprite.fromTexture(gooTexture, entity)
+        local gooSprite = drawableSprite.fromTexture(getGooTexture(entity), entity)
         gooSprite:setJustification(0.5, 0.5)
         gooSprite.rotation = math.pi / 2
         table.insert(sprites, gooSprite)

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -5,6 +5,9 @@ entities.canyon/pushblock.attributes.description.stickyBottom=Whether the bottom
 entities.canyon/pushblock.attributes.description.stickyLeft=Whether the left part is sticky.
 entities.canyon/pushblock.attributes.description.stickyRight=Whether the right part is sticky.
 entities.canyon/pushblock.attributes.description.isTemple=Whether it uses the temple sprite rather than the default.
+entities.canyon/pushblock.attributes.description.legacy=Whether this entity should have old functionality.\nThe current entity has received some physics tweaks, including fixing a bug where the block travels further when pushed left versus when pushed right.\nOn by default for every placement before the fix.
+entities.canyon/pushblock.attributes.description.customBlockTexture=A custom path relative to Graphics/Atlases/Gameplay/ for the texture of the block.\nIf the "isTemple" attribute is checked, the texture suffixed with "Temple" is used.\nDefault path: "objects/canyon/pushblock/idle"
+entities.canyon/pushblock.attributes.description.customGooTexture=A custom path relative to Graphics/Atlases/Gameplay/ for the subtextures of the sticky goo.\nThe subtextures are chosen at random, and each one is suffixed with a number from "00" to "03".\nOnly visible when at least one of the "sticky" attributes is checked.\nDefault path: "objects/canyon/pushblock/stickyGoo"
 
 # Spin Orb
 entities.canyon/spinorb.placements.name.SpinOrb=Spin Orb (Canyon)

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: CanyonHelper
-  Version: 1.1.4
+  Version: 1.1.5-dev
   DLL: Code/bin/CanyonHelper.dll
   Dependencies:
     - Name: EverestCore

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: CanyonHelper
-  Version: 1.1.5-dev
+  Version: 1.1.4
   DLL: Code/bin/CanyonHelper.dll
   Dependencies:
     - Name: EverestCore


### PR DESCRIPTION
Rework the function that moves the block by calling a different method. Added the "legacy" option for backwards compatibility.

This fixes a bug where the block travels further when pushed in one direction compared to the other, i.e. further to the left than to the right, further upwards than downwards. This also makes the block fall at the same speed as a Falling Block.

As this fix is only effective as long as "legacy" is off, it should not affect any Push Blocks that have already been placed.

Other additions include:
 - support for custom textures
 - small tweaks to debris and particle generation


Please let me know your thoughts on this. I'm especially wondering if small particle tweaks need to be toggled off by "legacy" or not