### PR TITLE
Addendum: Add option for custom debris

### DIFF
--- a/Code/PushBlock.cs
+++ b/Code/PushBlock.cs
@@ -75,6 +75,12 @@ namespace Celeste.Mod.CanyonHelper
             {
                 breakDebrisTileset = 'f';
             }
+
+            // Override debris data if enabled.
+            if (data.Bool("overrideDebris"))
+            {
+                breakDebrisTileset = data.Char("customDebrisFromTileset");
+            }
         }
 
         public override void Added(Scene scene)

--- a/Loenn/entities/pushblock.lua
+++ b/Loenn/entities/pushblock.lua
@@ -7,6 +7,13 @@ local pushblock = {}
 pushblock.name = "canyon/pushblock"
 pushblock.depth = -9999
 pushblock.fieldInformation = fakeTilesHelper.getFieldInformation("customDebrisFromTileset")
+pushblock.fieldOrder = {
+    "x", "y",
+    "customBlockTexture", "customGooTexture",
+    "customDebrisFromTileset", "overrideDebris", "isTemple",
+    "stickyTop", "stickyBottom", "stickyLeft", "stickyRight",
+    "legacy"
+}
 pushblock.placements = 
 {
     name = "PushBlock",
@@ -17,8 +24,8 @@ pushblock.placements =
         ["stickyRight"] = false,
         ["isTemple"] = false,
         legacy = false,
-        customBlockTexture = "",
-        customGooTexture = "",
+        customBlockTexture = "objects/canyon/pushblock/idle",
+        customGooTexture = "objects/canyon/pushblock/stickyGoo",
         overrideDebris = false,
         customDebrisFromTileset = "5"
     }

--- a/Loenn/entities/pushblock.lua
+++ b/Loenn/entities/pushblock.lua
@@ -1,9 +1,12 @@
 local drawableSprite = require("structs.drawable_sprite")
+local fakeTilesHelper = require("helpers.fake_tiles")
 local utils = require("utils")
+
 local pushblock = {}
 
 pushblock.name = "canyon/pushblock"
 pushblock.depth = -9999
+pushblock.fieldInformation = fakeTilesHelper.getFieldInformation("customDebrisFromTileset")
 pushblock.placements = 
 {
     name = "PushBlock",
@@ -15,7 +18,9 @@ pushblock.placements =
         ["isTemple"] = false,
         legacy = false,
         customBlockTexture = "",
-        customGooTexture = ""
+        customGooTexture = "",
+        overrideDebris = false,
+        customDebrisFromTileset = "5"
     }
 }
 

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -8,6 +8,8 @@ entities.canyon/pushblock.attributes.description.isTemple=Whether it uses the te
 entities.canyon/pushblock.attributes.description.legacy=Whether this entity should have old functionality.\nThe current entity has received some physics tweaks, including fixing a bug where the block travels further when pushed left versus when pushed right.\nOn by default for every placement before the fix.
 entities.canyon/pushblock.attributes.description.customBlockTexture=A custom path relative to Graphics/Atlases/Gameplay/ for the texture of the block.\nIf the "isTemple" attribute is checked, the texture suffixed with "Temple" is used.\nDefault path: "objects/canyon/pushblock/idle"
 entities.canyon/pushblock.attributes.description.customGooTexture=A custom path relative to Graphics/Atlases/Gameplay/ for the subtextures of the sticky goo.\nThe subtextures are chosen at random, and each one is suffixed with a number from "00" to "03".\nOnly visible when at least one of the "sticky" attributes is checked.\nDefault path: "objects/canyon/pushblock/stickyGoo"
+entities.canyon/pushblock.attributes.description.overrideDebris=Whether to override the debris spawned upon being dashed into, with custom debris data.
+entities.canyon/pushblock.attributes.description.customDebrisFromTileset=The debris associated with a tileset, to spawn upon being dashed into.\nFor custom tilesets, this is declared using the "debris" attribute in the XML.\nOnly in effect when the "overrideDebris" attribute is checked.
 
 # Spin Orb
 entities.canyon/spinorb.placements.name.SpinOrb=Spin Orb (Canyon)


### PR DESCRIPTION
Support for customising the debris emitted by the block when the player dashes into it, as long as the override option is enabled